### PR TITLE
mars: Move libcapiv2 blobs to sm8350-common

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -247,9 +247,6 @@ vendor/lib64/libcamera_nn_stub.so
 vendor/lib64/libcamera_scene.so
 vendor/lib64/libcamera_scene_dxo.so
 vendor/lib64/libcamerapostproc.so
-vendor/lib64/libcapiv2svacnn.so
-vendor/lib64/libcapiv2svarnn.so
-vendor/lib64/libcapiv2vop.so
 vendor/lib64/libchilog.so
 vendor/lib64/libcom.qti.chinodeutils.so
 vendor/lib64/libcvface_api.so


### PR DESCRIPTION
* module "libcapiv2vop" variant "android_vendor_arm64_armv8-2a_static": found in multiple namespaces (vendor/xiaomi/sm8350-common and vendor/xiaomi/mars) when including in vendor partition
* module "libcapiv2svacnn" variant "android_vendor_arm64_armv8-2a_static": found in multiple namespaces (vendor/xiaomi/sm8350-common and vendor/xiaomi/mars) when including in vendor partition
* module "libcapiv2svarnn" variant "android_vendor_arm64_armv8-2a_static": found in multiple namespaces (vendor/xiaomi/sm8350-common and vendor/xiaomi/mars) when including in vendor partition